### PR TITLE
v1.0.0 release: Portuguese support and doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **8 Language Support** - English, Spanish, French, German, Danish, Chinese, Hindi, Russian
+- **9 Language Support** - English, Spanish, French, German, Danish, Chinese, Hindi, Russian, Portuguese
   - Modular language files in `languages/` folder for easy community contributions
   - `toWords(n, { lang: 'es' })` for multi-language conversion
 - **New Functions**

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Transform any number into beautiful words. From `42` to `"forty-two"`, from `100
 - **Huge range** - Supports 0 to decillions (10^36) with BigInt
 - **Feature-rich** - Ordinals, decimals, currency, fractions, years, phone numbers
 - **Roman numerals** - Convert to and from Roman numerals
-- **Well tested** - 174 tests with 90%+ coverage
+- **Well tested** - 216 tests with 90%+ coverage
 - **Modern ES modules** - Tree-shakeable, TypeScript-friendly
 
 ## Installation

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@
 
 /**
  * numberstring - Convert numbers to their word representation
- * Supports English, Spanish, French, German, Danish, Mandarin Chinese, Hindi, and Russian
+ * Supports English, Spanish, French, German, Danish, Mandarin Chinese, Hindi, Russian, and Portuguese
  * @module numberstring
  */
 


### PR DESCRIPTION
## Summary

- **Portuguese language support** — new `languages/pt.js` with full number-to-words conversion, integrated into `toWords()` and exported from the package
- **Server tests** — 34 new API endpoint tests via supertest (`server/index.test.js`)
- **Doc fixes** — updated CHANGELOG (9 languages, not 8), README (216 tests, not 174), and JSDoc header to include Portuguese

## Details

All commits since last merge to master:

| Commit | Description |
|--------|-------------|
| `6dcfe3e` | feat: add Portuguese language support and server tests |
| `15e8b84` | fix: remove unused variables for eslint |
| `c5db19e` | fix: add supertest and express to devDependencies |
| `fa3b9e0` | fix(pt): add missing portuguese export and fix "e" connector |
| `dd6ac9b`–`fe7d4f1` | docs: CLAUDE.md updates (not published to npm) |
| `4b3dfe7` | docs: update language count and test count for Portuguese |

## Test plan

- [x] `npm test` — 216/216 passing
- [x] `npm run lint` — zero errors
- [ ] Verify `npm pack` output includes only intended files
- [ ] Publish to npm as `1.0.0` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)