### PR TITLE
fix(it): handle cento elision before otto/ottanta

### DIFF
--- a/languages/it.js
+++ b/languages/it.js
@@ -35,6 +35,11 @@ const tenment = (n, g) => hundment(n, g) % 100;
 const hundredIt = (n) => {
   if (n < 100 || n >= 1000) return '';
   const h = Math.floor(n / 100);
+  const remainder = n % 100;
+  // Elision: drop trailing 'o' before otto (8) and ottanta (80-89)
+  if (remainder >= 80 && remainder <= 89 || remainder === 8) {
+    return IT_HUNDREDS[h].slice(0, -1);
+  }
   return IT_HUNDREDS[h];
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1184,10 +1184,20 @@ describe('italian', () => {
     expect(italian(42)).toBe('quarantadue');
   });
 
-  it('handles elision rules', () => {
+  it('handles tens elision rules', () => {
     expect(italian(21)).toBe('ventuno');
     expect(italian(28)).toBe('ventotto');
     expect(italian(23)).toBe('ventitré');
+  });
+
+  it('handles cento elision before otto/ottanta', () => {
+    expect(italian(108)).toBe('centotto');
+    expect(italian(180)).toBe('centottanta');
+    expect(italian(188)).toBe('centottantotto');
+    expect(italian(208)).toBe('duecentotto');
+    expect(italian(280)).toBe('duecentottanta');
+    expect(italian(808)).toBe('ottocentotto');
+    expect(italian(880)).toBe('ottocentottanta');
   });
 
   it('converts thousands', () => {


### PR DESCRIPTION
## Summary

- Fix Italian `cento` elision: drops trailing "o" before words starting with "o" (otto=8, ottanta=80-89)
- `108` → `centotto` (was `centootto`)
- `180` → `centottanta` (was `centoottanta`)
- Works for all hundreds: `duecentotto`, `ottocentottanta`, etc.
- 7 new test cases added (266 total)

## Test plan

- [x] `npm run lint` — zero errors
- [x] `npm test` — 266/266 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)